### PR TITLE
Make default web root configurable

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -6,6 +6,7 @@ php_config_file="/etc/php5/apache2/php.ini"
 xdebug_config_file="/etc/php5/mods-available/xdebug.ini"
 mysql_config_file="/etc/mysql/my.cnf"
 default_apache_index="/var/www/html/index.html"
+project_web_root="/src"
 
 # This function is called at the very bottom of the file
 main() {
@@ -60,13 +61,13 @@ apache_go() {
 	cat << EOF > ${apache_vhost_file}
 <VirtualHost *:80>
         ServerAdmin webmaster@localhost
-        DocumentRoot /vagrant/src
+        DocumentRoot /vagrant${project_web_root}
         LogLevel debug
 
         ErrorLog /var/log/apache2/error.log
         CustomLog /var/log/apache2/access.log combined
 
-        <Directory /vagrant/src>
+        <Directory /vagrant${project_web_root}>
             AllowOverride All
             Require all granted
         </Directory>


### PR DESCRIPTION
There are quite a few common paths used as the web-root for projects such as `/src` `/dist` `/www` and so on.
This minimal pull request makes it easily configurable